### PR TITLE
fix: make the pb symlink relative

### DIFF
--- a/go-protoc-binary/proto/greeter.pb.go
+++ b/go-protoc-binary/proto/greeter.pb.go
@@ -1,1 +1,1 @@
-/home/filmil/code/bazel-experiments/go-protoc-binary/bazel-bin/proto/greeter_go_proto_/example.com/greeter_proto/greeter.pb.go
+../bazel-bin/proto/greeter_go_proto_/example.com/greeter_proto/greeter.pb.go


### PR DESCRIPTION
This is not needed for bazel, but allows LSPs to work as you're used to.